### PR TITLE
Compatibility fixes for newer Python & PyYAML versions

### DIFF
--- a/cloud_formation_viz/main.py
+++ b/cloud_formation_viz/main.py
@@ -11,7 +11,7 @@ from numbers import Number
 def flatten(x):
     result = []
     for el in x:
-        if isinstance(x, collections.Iterable) and not isinstance(el, dict):
+        if isinstance(x, collections.abc.Iterable) and not isinstance(el, dict):
             result.extend(flatten(el))
         else:
             result.append(el)
@@ -40,7 +40,7 @@ def open_cfn(argv):
                 cfn_intrinsic_functions = ['!GetAtt', '!Ref', '!Sub']
                 for f in cfn_intrinsic_functions:
                     text = text.replace(f,' ')
-                template = yaml.load(text)
+                template = yaml.load(text, Loader=yaml.Loader)
             else:
                 template = json.load(h)
     else:


### PR DESCRIPTION
Tested on Python 3.10 & PyYAML 6.0.

Fixes the two errors below:
```
Traceback (most recent call last):
  File "/Users/alp/src/cloud-formation-viz/.venv/bin/cfviz", line 33, in <module>
    sys.exit(load_entry_point('cloud-formation-viz==0.0.1', 'console_scripts', 'cfviz')())
  File "/Users/alp/src/cloud-formation-viz/.venv/lib/python3.10/site-packages/cloud_formation_viz-0.0.1-py3.10.egg/cloud_formation_viz/main.py", line 22, in main
    template = open_cfn(sys.argv)
  File "/Users/alp/src/cloud-formation-viz/.venv/lib/python3.10/site-packages/cloud_formation_viz-0.0.1-py3.10.egg/cloud_formation_viz/main.py", line 43, in open_cfn
    template = yaml.load(text)
TypeError: load() missing 1 required positional argument: 'Loader'
```

```
Traceback (most recent call last):
  File "/Users/alp/src/cloud-formation-viz/.venv/bin/cfviz", line 33, in <module>
    sys.exit(load_entry_point('cloud-formation-viz==0.0.1', 'console_scripts', 'cfviz')())
  File "/Users/alp/src/cloud-formation-viz/.venv/lib/python3.10/site-packages/cloud_formation_viz-0.0.1-py3.10.egg/cloud_formation_viz/main.py", line 24, in main
    (graph, edges) = extract_graph(template.get('Description', ''), template['Resources'])
  File "/Users/alp/src/cloud-formation-viz/.venv/lib/python3.10/site-packages/cloud_formation_viz-0.0.1-py3.10.egg/cloud_formation_viz/main.py", line 76, in extract_graph
    edges.extend(flatten(find_refs(item, details)))
  File "/Users/alp/src/cloud-formation-viz/.venv/lib/python3.10/site-packages/cloud_formation_viz-0.0.1-py3.10.egg/cloud_formation_viz/main.py", line 14, in flatten
    if isinstance(x, collections.Iterable) and not isinstance(el, dict):
AttributeError: module 'collections' has no attribute 'Iterable'
```